### PR TITLE
Add title to Input for better HTML validation messages

### DIFF
--- a/src/Input.js
+++ b/src/Input.js
@@ -12,6 +12,7 @@ export default class Input extends React.Component {
     placeholder: React.PropTypes.string,
     required: React.PropTypes.bool,
     autofocus: React.PropTypes.bool,
+    title: React.PropTypes.string,
     type: React.PropTypes.string.isRequired,
     value: React.PropTypes.any,
     offValue: React.PropTypes.any,
@@ -98,6 +99,7 @@ export default class Input extends React.Component {
         placeholder={ this.props.placeholder }
         ref="input"
         required={ this.props.required }
+        title={ this.props.title }
         type={ this.props.type }
       />
     );


### PR DESCRIPTION
Since `onSubmit` doesn't get fired before input validation is done by the browser, you're stuck with the default message on the popup.  Setting the title appends your message to the default.

WITHOUT TITLE:
![screen shot 2016-09-12 at 2 38 46 pm](https://cloud.githubusercontent.com/assets/11298654/18454132/ec6c40ba-78ff-11e6-910b-f7693de6cbcb.png)

WITH:
![screen shot 2016-09-12 at 3 44 35 pm](https://cloud.githubusercontent.com/assets/11298654/18454137/f2174ee2-78ff-11e6-8f8d-9d709419c65c.png)
![screen shot 2016-09-12 at 2 29 54 pm](https://cloud.githubusercontent.com/assets/11298654/18454141/f6441388-78ff-11e6-88e1-8dacd2c71039.png)

